### PR TITLE
fix cluster use for parallel processing

### DIFF
--- a/R/scrolling_spectro.R
+++ b/R/scrolling_spectro.R
@@ -449,7 +449,7 @@ scrolling_spectro <- function(wave, file.name = "scroll.spectro.mp4", hop.size =
   }, cl = cl)
   
   # stop clusters for windows OS
-  stopCluster(cl = cl)
+  parallel::stopCluster(cl = cl)
   rm(cl)
   
   # temporary file names


### PR DESCRIPTION
I love this package - but I've found it to be very slow. Running `scrolling_spectro()` on my computer (fairly powerful - 6 core processor) generally took about 1 minute of processing time per second of input audio.

I found that (on my system, at least - Windows 10) the pblapply portion of `scrolling_spectro()` did not appear to be using the parallel processing capacity built in to the function - despite being by far the slowest part of the function. I've fixed this - I think - it certainly speeds up the processing time, and looking at task manager it appears to now properly use the cores I tell it to.