### PR TITLE
Various fixes to Matt's part of the package--bump version to 1.0.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dynaSpec
 Type: Package
 Title: Dynamic Spectrogram Visualizations
-Version: 1.0.2
+Version: 1.0.3
 Date: 2024-02-20
 Description: A set of tools to generate dynamic spectrogram visualizations in video format.
 License: GPL (>= 2)
@@ -13,7 +13,7 @@ URL: https://github.com/maRce10/dynaSpec
 BugReports: https://github.com/maRce10/dynaSpec/issues
 NeedsCompilation: no
 Suggests: parallel, imager, fs
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Repository: CRANs
 Language: en-US
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# *dynaSpec 1.0.3*
+
+* Fix logic for crop and xLim in prep_static_ggspectro()
+* Other fixes to have more predictable behavior of exported MP4 videos using "Matt's approach" with paged_spectro()
+* Added title parameter to add a title to both static and subsequent paged spectrogram (MP4)
+* Added resampleRate parameter to prep_static_ggspectro() for control over resolution of spectrogram (and to speed things up)
+
 # *dynaSpec 1.0.1*
 
 * Fix resampling issue when sampling rate of waves != 44.1 kHz

--- a/R/ggSpec.R
+++ b/R/ggSpec.R
@@ -3,6 +3,7 @@
 ggSpec <-
   function(wav,
            soundFile,
+           resampleRate,
            segLens,
            savePNG,
            specWidth,
@@ -34,8 +35,7 @@ ggSpec <-
       nSegs = length(segLens) - 1
     }
     
-    
-    # bg="#ebe834"
+      # bg="#ebe834"
     #Font color adapted from https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
     
     if (is.null(fontAndAxisCol)) {
@@ -56,6 +56,14 @@ ggSpec <-
     # plot(1,1,col="transparent")
     # text(1,1,"READABLE?",cex=5,col=contrastFont)
     
+    
+       
+  if(!is.null(resampleRate)){
+    wav0 <- wav #backup
+   message("Original wav (",wav0@samp.rate,"samples/sec) data points: ",length(wav0@left))
+    wav <- tuneR::downsample(wav,samp.rate=resampleRate)
+    message("Original wav (",wav@samp.rate,"samples/sec) data points: ",length(wav@left))
+  }
     
     #Modified from seewave::ggspectro
     #--->

--- a/R/ggSpec.R
+++ b/R/ggSpec.R
@@ -8,6 +8,7 @@ ggSpec <-
            specWidth,
            specHeight,
            destFolder,
+           title,
            ovlp,
            wl,
            wn,
@@ -108,13 +109,15 @@ ggSpec <-
       
       level=NULL #just to shut up the check
       
-      #Plot that thang
-      #      #
+
+# Plot that thang ---------------------------------------------------------
+
       Glist[[i]] <-
         ggplot2::ggplot(df_i, ggplot2::aes(x = time, y = freq, z = amplitude)) +
         ggplot2::xlim(segLens[i], segLens[i + 1]) + ggplot2::ylim(yLim) +
         #Labels
-        ggplot2::labs(x = "Time (s)", y = "Frequency (kHz)", fill = "Amplitude\n(dB)\n") +
+        ggplot2::labs(x = "Time (s)", y = "Frequency (kHz)", fill = "Amplitude\n(dB)\n",
+                      title=title) +
         {
           #Set scale according to viridis or custom color scheme
           if (isViridis) {

--- a/R/paged_spectro.R
+++ b/R/paged_spectro.R
@@ -8,15 +8,13 @@
 #' is defined by the xLim parameter in \code{\link{prep_static_ggspectro}}. You can also output temporary segmented files, if desired.
 #' 
 #' @aliases pagedSpectro pagedSpec
-#' @usage paged_spectro(specParams,destFolder,vidName,framerate=30,highlightCol="#4B0C6BFF",
-#' highlightAlpha=.6,cursorCol="#4B0C6BFF",delTemps=TRUE)
 #' @param specParams an object returned from \code{\link{prep_static_ggspectro}}
 #' @param destFolder destination of output video; this setting overwrites setting from specParams object
 #' @param vidName expects "FileName", .mp4 not necessary; if not supplied, will be named after the file you used in prep_static_ggspectro()
 #' @param highlightCol default "#4B0C6BFF" (a purple color to match the default viridis 'inferno' palette)
 #' @param highlightAlpha opacity of the highlight box; default is 0.6
 #' @param cursorCol    Color of the leading edge of the highlight box; default "white"
-#' @param delTemps   Default= TRUE, deletes temporary files (specs & WAV files used to create concatenated video)
+#' @param delete_temp_files   Default= TRUE, deletes temporary files (specs & WAV files used to create concatenated video)
 #' @param framerate by default, set to 30 (currently this is not supported, as animate doesn't honor the setting)
 #' @return Nothing is returned, though progress and file save locations are output to user. Video should play after rendering.
 #' @seealso \code{\link{prep_static_ggspectro}}
@@ -58,7 +56,7 @@
 #' # see more examples at https://marce10.github.io/dynaSpec/
 #' }
 
-paged_spectro <-function(specParams,destFolder,vidName,framerate=30,highlightCol="#4B0C6BFF",highlightAlpha=.6,cursorCol="white",delTemps=TRUE)
+paged_spectro <-function(specParams,destFolder,vidName,framerate=30,highlightCol="#4B0C6BFF",highlightAlpha=.6,cursorCol="white",delete_temp_files=TRUE)
 {
  xmin<-ymin <- xmax <- ymax <- NULL 
  #This ^^ suppresses note about "no visible binding for global variable ‘xmax’"
@@ -225,7 +223,7 @@ for(i in 1:length(specParams$segWavs))
   cat(paste0("file saved @",vidName))
   system(paste0('open "',vidName,'"'))
   
-  if(delTemps){unlink(tempdir,recursive=TRUE);print(paste0("FYI temporary file directory deleted @ ",tempdir))}
+  if(delete_temp_files){unlink(tempdir,recursive=TRUE);print(paste0("FYI temporary file directory deleted @ ",tempdir))}
 }#end else which passed FFMPEG check
 }#end paged_spectro definition
 

--- a/R/paged_spectro.R
+++ b/R/paged_spectro.R
@@ -129,12 +129,12 @@ for(i in 1:length(specParams$segWavs))
    cursor<-seq(range_i[1],range_i[2],specParams$xLim[2]/framerate)
   played<-data.frame(xmin=cursor,xmax=rep(range_i[2],length(cursor)),ymin=rep(specParams$yLim[1],length(cursor)),ymax=rep(specParams$yLim[2], length(cursor)))
   
-
   #Make ggplot overlay of highlight box on spectrogram
   vidSegment<-{
     ggplot2::ggplot(played)+ggplot2::xlim(range_i)+ggplot2::ylim(specParams$yLim)+
       #Labels
-      ggplot2::labs(x="Time (s)",y="Frequency (kHz)",fill="Amplitude\n(dB)\n")+
+      ggplot2::labs(x="Time (s)",y="Frequency (kHz)",fill="Amplitude\n(dB)\n",
+                    title=specParams$title)+
       ##Animate() seems to shrink font size a bit
       mytheme_lg(specParams$bg)+
       

--- a/R/paged_spectro.R
+++ b/R/paged_spectro.R
@@ -219,11 +219,13 @@ for(i in 1:length(specParams$segWavs))
    
   }
 
-  cat("\n\nAll done!\n")
-  cat(paste0("file saved @",vidName))
+  message("\n\nAll done!\nfile saved @",vidName)
   system(paste0('open "',vidName,'"'))
   
-  if(delete_temp_files){unlink(tempdir,recursive=TRUE);print(paste0("FYI temporary file directory deleted @ ",tempdir))}
+  if(delete_temp_files){
+    unlink(tempdir,recursive=TRUE)
+    message("FYI temporary file directory deleted @ ",tempdir)
+    }
 }#end else which passed FFMPEG check
 }#end paged_spectro definition
 

--- a/R/paged_spectro.R
+++ b/R/paged_spectro.R
@@ -15,7 +15,7 @@
 #' @param vidName expects "FileName", .mp4 not necessary; if not supplied, will be named after the file you used in prep_static_ggspectro()
 #' @param highlightCol default "#4B0C6BFF" (a purple color to match the default viridis 'inferno' palette)
 #' @param highlightAlpha opacity of the highlight box; default is 0.6
-#' @param cursorCol    Color of the leading edge of the highlight box; default "#4B0C6BFF"
+#' @param cursorCol    Color of the leading edge of the highlight box; default "white"
 #' @param delTemps   Default= TRUE, deletes temporary files (specs & WAV files used to create concatenated video)
 #' @param framerate by default, set to 30 (currently this is not supported, as animate doesn't honor the setting)
 #' @return Nothing is returned, though progress and file save locations are output to user. Video should play after rendering.
@@ -58,7 +58,7 @@
 #' # see more examples at https://marce10.github.io/dynaSpec/
 #' }
 
-paged_spectro <-function(specParams,destFolder,vidName,framerate=30,highlightCol="#4B0C6BFF",highlightAlpha=.6,cursorCol="#4B0C6BFF",delTemps=TRUE)
+paged_spectro <-function(specParams,destFolder,vidName,framerate=30,highlightCol="#4B0C6BFF",highlightAlpha=.6,cursorCol="white",delTemps=TRUE)
 {
  xmin<-ymin <- xmax <- ymax <- NULL 
  #This ^^ suppresses note about "no visible binding for global variable ‘xmax’"

--- a/R/paged_spectro.R
+++ b/R/paged_spectro.R
@@ -97,7 +97,7 @@ if(!missing(vidName)){
     outWAV<-lapply(1:length(specParams$segWavs),function(x) {paste0(tempdir,iName0,"_",x,"_.wav")}) 
     invisible(
       lapply(1:length(specParams$segWavs), function(x){fn=outWAV[[x]]
-          tuneR::writeWave(specParams$segWavs[[x]],file=fn)
+          tuneR::writeWave(specParams$segWavs[[x]],filename=fn)
           cat(paste0("\nSaved temp wav segment: ",fn))}))
       }
     

--- a/R/prep_static_ggspectro.R
+++ b/R/prep_static_ggspectro.R
@@ -20,6 +20,7 @@
 #' @param crop subset of recording to include; default crop=NULL will use whole file, up to 10 sec; if a number, interpreted as crop first X.X sec; if c(X1,X2), interpreted as trimming out a specific time interval in sec; if crop=FALSE, will not crop at all, even for recordings over 10 sec.
 #' @param xLim the time limit (x-axis width) in seconds for all spectrograms; i.e. page width in seconds for multi-page dynamic spectrograms (defaults to WAV file length, unless file duration >5s). To override the 5s limit, put xLim=Inf or specify the desired spectrogram x-axis limit.
 #' @param yLim the frequency limits (y-axis); default is c(0,10) aka 0-10kHz
+#' @param title string for title of plots; default=NULL
 #' @param plotLegend logical; include a legend showing amplitude colors? default=FALSE
 #' @param onlyPlotSpec logical; do you want to just plot the spec and leave out the legend, axes, and axis labels? default= TRUE
 #' @param ampTrans amplitude transform for boosting spectrum contrast; default=1 (actual dB values); specify a decimal number for the lambda value of scales::modulus_trans(); 2.5 is a good place to start. (This amplifies your loud values the most, while not increasing background noise much at all)
@@ -72,12 +73,15 @@
 #' maleBarnSwallow<-prep_static_ggspectro(f[2],destFolder="wd",onlyPlotSpec = FALSE,
 #' bgFlood=TRUE,ampTrans=2,min_dB=-40)
 #'
-#' #much stronger, now let's combine them (you need the cowplot package)
+#' #much stronger, now let's combine them 
+#' (you need the patchwork package to use the / operator to stack plots)
+#' library(patchwork)
+#' (femaleBarnSwallow$spec[[1]]+ggplot2::xlim(0,5)) /
+#' (maleBarnSwallow$spec[[1]]+ggplot2::xlim(0,5))  + 
+#' patchwork::plot_annotation(title="Female and Male barn swallow songs",
+#' caption="Female song (top) is much shorter, but similar complexity to males. See: MR Wilkins et al. (2020) Animal Behaviour 168")
 #'
-#' # cowplot::plot_grid(femaleBarnSwallow$spec[[1]]+xlim(0,5)+ggtitle("female barn swallow song"),
-#' # maleBarnSwallow$spec[[1]]+xlim(0,5)+ggtitle("male barn swallow song"),ncol=1,labels="auto")
-#'
-#' # ggsave("M&F_barn_swallow_song_specs.jpeg")
+#' # ggplot2::ggsave("M&F_barn_swallow_song_specs.jpeg",width=11,height=7)
 #'
 #' # see more examples at https://marce10.github.io/dynaSpec/
 #' }
@@ -98,6 +102,7 @@ prep_static_ggspectro <-
            filter = NULL,
            xLim = NULL,
            yLim = c(0, 10),
+           title=NULL,
            plotLegend = FALSE,
            onlyPlotSpec = TRUE,
            ampTrans = 1,
@@ -212,7 +217,6 @@ prep_static_ggspectro <-
                    xLim = xLim,
                    filter = filter,
                    ampThresh)
-    browser()
     if (length(yLim) == 1) {
       yLim = c(0, yLim)
     }
@@ -227,6 +231,7 @@ prep_static_ggspectro <-
         specWidth = specWidth,
         specHeight = specHeight,
         destFolder = destFolder,
+        title = title,
         colPal = colPal,
         isViridis = isViridis,
         crop = crop,

--- a/R/prep_static_ggspectro.R
+++ b/R/prep_static_ggspectro.R
@@ -23,7 +23,7 @@
 #' @param title string for title of plots; default=NULL
 #' @param plotLegend logical; include a legend showing amplitude colors? default=FALSE
 #' @param onlyPlotSpec logical; do you want to just plot the spec and leave out the legend, axes, and axis labels? default= TRUE
-#' @param resampleRate a number in Hz to downsample audio for spectrogram only. This will simplify audio data and speed up generation of spectrogram. Passed to [tuneR::downsample()]. Put NULL to keep original sample rate for spectrogram.
+#' @param resampleRate a number in Hz to downsample audio for spectrogram only. This will simplify audio data and speed up generation of spectrogram. Passed to [tuneR::downsample()]. Default=15000 shaves off a few seconds without losing much quality. Put NULL to keep original sample rate for spectrogram. Audiofile will not be resampled for MP4.
 #' @param ampTrans amplitude transform for boosting spectrum contrast; default=1 (actual dB values); specify a decimal number for the lambda value of scales::modulus_trans(); 2.5 is a good place to start. (This amplifies your loud values the most, while not increasing background noise much at all)
 #' @param min_dB the minimum decibel (quietest sound) to include in the spec; defaults to -30 (-40 would include quieter sounds; -20 would cut out all but very loud sounds)
 #' @param filter apply a bandpass filter? Defaults to none (NULL). Expects 'c(0,2)' where sound from 0 to 2kHz would be filtered out
@@ -107,7 +107,7 @@ prep_static_ggspectro <-
            plotLegend = FALSE,
            onlyPlotSpec = TRUE,
            ampTrans = 1,
-           resampleRate = NULL,
+           resampleRate = 15000,
            min_dB = -30,
            wl = 512,
            ovlp = 90,

--- a/R/prep_static_ggspectro.R
+++ b/R/prep_static_ggspectro.R
@@ -270,6 +270,7 @@ prep_static_ggspectro <-
       isViridis = isViridis,
       xLim = prepped$xLim,
       yLim = yLim,
+      title = title,
       plotLegend = plotLegend,
       onlyPlotSpec = onlyPlotSpec,
       ampTrans = ampTrans,

--- a/R/prep_static_ggspectro.R
+++ b/R/prep_static_ggspectro.R
@@ -23,6 +23,7 @@
 #' @param title string for title of plots; default=NULL
 #' @param plotLegend logical; include a legend showing amplitude colors? default=FALSE
 #' @param onlyPlotSpec logical; do you want to just plot the spec and leave out the legend, axes, and axis labels? default= TRUE
+#' @param resampleRate a number in Hz to downsample audio for spectrogram only. This will simplify audio data and speed up generation of spectrogram. Passed to [tuneR::downsample()]. Put NULL to keep original sample rate for spectrogram.
 #' @param ampTrans amplitude transform for boosting spectrum contrast; default=1 (actual dB values); specify a decimal number for the lambda value of scales::modulus_trans(); 2.5 is a good place to start. (This amplifies your loud values the most, while not increasing background noise much at all)
 #' @param min_dB the minimum decibel (quietest sound) to include in the spec; defaults to -30 (-40 would include quieter sounds; -20 would cut out all but very loud sounds)
 #' @param filter apply a bandpass filter? Defaults to none (NULL). Expects 'c(0,2)' where sound from 0 to 2kHz would be filtered out
@@ -106,6 +107,7 @@ prep_static_ggspectro <-
            plotLegend = FALSE,
            onlyPlotSpec = TRUE,
            ampTrans = 1,
+           resampleRate = NULL,
            min_dB = -30,
            wl = 512,
            ovlp = 90,
@@ -216,7 +218,8 @@ prep_static_ggspectro <-
                    crop = crop,
                    xLim = xLim,
                    filter = filter,
-                   ampThresh)
+                   ampThresh=ampThresh)
+    
     if (length(yLim) == 1) {
       yLim = c(0, yLim)
     }
@@ -226,6 +229,7 @@ prep_static_ggspectro <-
       ggSpec(
         wav = prepped$newWav,
         soundFile = soundFile,
+        resampleRate = resampleRate,
         segLens = prepped$segLens,
         savePNG = savePNG,
         specWidth = specWidth,

--- a/R/prep_static_ggspectro.R
+++ b/R/prep_static_ggspectro.R
@@ -269,6 +269,7 @@ prep_static_ggspectro <-
       soundFile = soundFile,
       destFolder = destFolder,
       outFilename = outFilename,
+      n_pages= length(prepped$segWavs),
       crop = crop,
       colPal = colPal,
       isViridis = isViridis,

--- a/R/prep_static_ggspectro.R
+++ b/R/prep_static_ggspectro.R
@@ -7,11 +7,6 @@
 #'
 #' @aliases prepStaticSpec prepStaticGGspec
 #'
-#' @usage prep_static_ggspectro(soundFile,destFolder,outFilename,savePNG=FALSE,colPal="inferno",
-#' crop=NULL,bg=NULL,filter=NULL,xLim=NULL,yLim=c(0,10),plotLegend=FALSE,onlyPlotSpec=TRUE,
-#' ampTrans=1,min_dB=-30,wl=512, ovlp=90,wn="blackman",specWidth=9,specHeight=3,
-#' colbins=30,ampThresh=0,bgFlood=FALSE,fontAndAxisCol=NULL,optim=NULL,...)
-#'
 #' @param soundFile should work with URLs, full and relative paths; handles .mp3 and .wav
 #' @param destFolder path to directory to save output. Needs to be like "figures/spectrograms/" to be relative to working directory. Default=parent folder of soundFile. Specify "wd" to output to the working directory, gotten from [get_wd()]
 #' @param outFilename name for output PNG. default=NULL will use input name in output filename.

--- a/R/processSound.R
+++ b/R/processSound.R
@@ -108,9 +108,7 @@ processSound <- function(wav0, filter, ampThresh, crop, xLim, ...) {
   
   # Make wav file match page xlims ------------------------------------------
   #Given xLim, what is the full length the recording needs to be?
-  max_page_dur <- ceiling(wavDur / xLim[2]) * xLim[2]
-  
-  #Add silence at the end if (user-supplied) xLim>cropped Duration or xLim doesn't divide into even segments of wave duration
+  max_page_dur <- ceiling( round(wavDur,digits=2) / xLim[2]) * xLim[2]
   
   timeRemainder <-
     (max_page_dur - wavDur)
@@ -140,10 +138,12 @@ processSound <- function(wav0, filter, ampThresh, crop, xLim, ...) {
         bit = wav@bit
       )
     wav <- tuneR::bind(wav, fillerWAV)
+  }
+  
     #pastew results in intermittent problems! Don't use! bind seems much more dependable
     #seewave::pastew(wave1=fillerWAV,wave2=wav,at="end",output="Wave",join=T,bit=wav0@bit)
     wavDur <- max(length(wav@left), length(wav@right)) / wav@samp.rate
-  }
+  
   #Segment wav or make list of 1 if no segmentation
   #The ceiling code here is to deal with e.g. duration of 29.999 and xLim=10 that would only produce 2 segments
   

--- a/R/processSound.R
+++ b/R/processSound.R
@@ -98,11 +98,11 @@ processSound <- function(wav0, filter, ampThresh, crop, xLim, ...) {
   timeRemainder <-
     (ceiling(wavDur / xLim[2]) * xLim[2] - wavDur) > 0.001#(wavDur%/%xLim[2]-wavDur/xLim[2]
   #If user wants to have xLim be Infinite (override 5sec max for long files)
-  if(xLim[2] %in% c(Inf,"Inf")){
+  if (xLim[2] %in% c(Inf, "Inf")) {
     wavDur <- max(length(wav@left), length(wav@right)) / wav@samp.rate
     xLim[2] <- wavDur
-  #Else fill out remainders with filler silence
-  }else if (xLim[2] > wavDur | timeRemainder ) {
+    #Else fill out remainders with filler silence
+  } else if (xLim[2] > wavDur | timeRemainder) {
     if (timeRemainder) {
       diffT <- ceiling(wavDur / xLim[2]) * xLim[2] - wavDur
     } else{
@@ -122,7 +122,8 @@ processSound <- function(wav0, filter, ampThresh, crop, xLim, ...) {
     wavDur <- max(length(wav@left), length(wav@right)) / wav@samp.rate
   }
   #Segment wav or make list of 1 if no segmentation
-  segLens <- seq(0, wavDur, xLim[2])
+  #The ceiling code here is to deal with e.g. duration of 29.999 and xLim=10 that would only produce 2 segments
+  segLens <- seq(0, ceiling(wavDur/xLim[2])*xLim[2], xLim[2])
   indx <- 1:(length(segLens) - 1)
   segWavs <-
     lapply(indx, function(i)
@@ -133,7 +134,7 @@ processSound <- function(wav0, filter, ampThresh, crop, xLim, ...) {
         output = "Wave",
         bit = wav0@bit
       ))
-  #browser()
+  
   return(list(
     newWav = wav,
     segWavs = segWavs,

--- a/R/processSound.R
+++ b/R/processSound.R
@@ -96,7 +96,7 @@ processSound <- function(wav0, filter, ampThresh, crop, xLim, ...) {
   
   #Add silence at the end if (user-supplied) xLim>cropped Duration or xLim doesn't divide into even segments of wave duration
   timeRemainder <-
-    (ceiling(wavDur / xLim[2]) * xLim[2] - wavDur) > 0.001#(wavDur%/%xLim[2]-wavDur/xLim[2]
+    (ceiling(wavDur / xLim[2]) * xLim[2] - wavDur) > 0#(wavDur%/%xLim[2]-wavDur/xLim[2]
   #If user wants to have xLim be Infinite (override 5sec max for long files)
   if (xLim[2] %in% c(Inf, "Inf")) {
     wavDur <- max(length(wav@left), length(wav@right)) / wav@samp.rate

--- a/man/paged_spectro.Rd
+++ b/man/paged_spectro.Rd
@@ -6,8 +6,16 @@
 \alias{pagedSpec}
 \title{Make a paged dynamic spectrogram similar to spectral display in Adobe Audition}
 \usage{
-paged_spectro(specParams,destFolder,vidName,framerate=30,highlightCol="#4B0C6BFF",
-highlightAlpha=.6,cursorCol="#4B0C6BFF",delTemps=TRUE)
+paged_spectro(
+  specParams,
+  destFolder,
+  vidName,
+  framerate = 30,
+  highlightCol = "#4B0C6BFF",
+  highlightAlpha = 0.6,
+  cursorCol = "white",
+  delete_temp_files = TRUE
+)
 }
 \arguments{
 \item{specParams}{an object returned from \code{\link{prep_static_ggspectro}}}
@@ -22,9 +30,9 @@ highlightAlpha=.6,cursorCol="#4B0C6BFF",delTemps=TRUE)
 
 \item{highlightAlpha}{opacity of the highlight box; default is 0.6}
 
-\item{cursorCol}{Color of the leading edge of the highlight box; default "#4B0C6BFF"}
+\item{cursorCol}{Color of the leading edge of the highlight box; default "white"}
 
-\item{delTemps}{Default= TRUE, deletes temporary files (specs & WAV files used to create concatenated video)}
+\item{delete_temp_files}{Default= TRUE, deletes temporary files (specs & WAV files used to create concatenated video)}
 }
 \value{
 Nothing is returned, though progress and file save locations are output to user. Video should play after rendering.

--- a/man/prep_static_ggspectro.Rd
+++ b/man/prep_static_ggspectro.Rd
@@ -14,33 +14,33 @@ colbins=30,ampThresh=0,bgFlood=FALSE,fontAndAxisCol=NULL,optim=NULL,...)
 \arguments{
 \item{soundFile}{should work with URLs, full and relative paths; handles .mp3 and .wav}
 
-\item{destFolder}{needs to be like "figures/spectrograms/" to be relative to working directory; goes to soundFile folder by default or working directory if soundFile is a URL; can specify "wd" to output to the working directory}
+\item{destFolder}{path to directory to save output. Needs to be like "figures/spectrograms/" to be relative to working directory. Default=parent folder of soundFile. Specify "wd" to output to the working directory, gotten from [get_wd()]}
 
-\item{outFilename}{if left out, will use input name in output filename}
+\item{outFilename}{name for output PNG. default=NULL will use input name in output filename.}
 
-\item{savePNG}{save static spectrograms as PNGs? They will be exported to destFolder}
+\item{savePNG}{logical; Save static spectrograms as PNGs? They will be exported to destFolder.}
 
 \item{colPal}{color palette; one of "viridis","magma","plasma","inferno","cividis" from the \code{\link[viridis]{viridis}} package OR a 2 value vector (e.g. c("white","black")), defining the start and end of a custom color gradient}
 
-\item{crop}{subset of recording to include; if crop=NULL, use whole file; if number, interpreted as crop first X.X sec; if c(X1,X2), interpreted as specific time interval in sec}
+\item{crop}{subset of recording to include; default crop=NULL will use whole file, up to 10 sec; if a number, interpreted as crop first X.X sec; if c(X1,X2), interpreted as trimming out a specific time interval in sec; if crop=FALSE, will not crop at all, even for recordings over 10 sec.}
 
 \item{bg}{background color (defaults to 1st value of chosen palette)}
 
 \item{filter}{apply a bandpass filter? Defaults to none (NULL). Expects 'c(0,2)' where sound from 0 to 2kHz would be filtered out}
 
-\item{xLim}{is the time limit in seconds for all spectrograms; i.e. page width in seconds for multi-page dynamic spectrograms (defaults to WAV file length, unless file duration >5s). To override the 5s limit, put xLim=Inf.}
+\item{xLim}{the time limit (x-axis width) in seconds for all spectrograms; i.e. page width in seconds for multi-page dynamic spectrograms (defaults to WAV file length, unless file duration >5s). To override the 5s limit, put xLim=Inf or specify the desired spectrogram x-axis limit.}
 
-\item{yLim}{is the frequency limits (y-axis); default is c(0,10) aka 0-10kHz}
+\item{yLim}{the frequency limits (y-axis); default is c(0,10) aka 0-10kHz}
 
-\item{plotLegend}{include a legend showing amplitude colors?}
+\item{plotLegend}{logical; include a legend showing amplitude colors? default=FALSE}
 
-\item{onlyPlotSpec}{do you want to just plot the spec and leave out the legend, axes, and axis labels?}
+\item{onlyPlotSpec}{logical; do you want to just plot the spec and leave out the legend, axes, and axis labels? default= TRUE}
 
-\item{ampTrans}{amplitude transform for boosting spectrum contrast; defaults to identity (actual dB values); specify a decimal number for the lambda value of scales::modulus_trans(); 2.5 is a good place to start. (This amplifies your loud values the most, while not increasing background noise much at all)}
+\item{ampTrans}{amplitude transform for boosting spectrum contrast; default=1 (actual dB values); specify a decimal number for the lambda value of scales::modulus_trans(); 2.5 is a good place to start. (This amplifies your loud values the most, while not increasing background noise much at all)}
 
 \item{min_dB}{the minimum decibel (quietest sound) to include in the spec; defaults to -30 (-40 would include quieter sounds; -20 would cut out all but very loud sounds)}
 
-\item{wl}{window length for the spectrogram (low values= higher temporal res; high values= higher freq. res). Default 512 is a good tradeoff}
+\item{wl}{window length for the spectrogram (low values= higher temporal res; high values= higher freq. res). Default 512 is a good tradeoff; human speech would look better at 1024 or higher, giving higher frequency resolution.}
 
 \item{ovlp}{how much overlap (as percent) between sliding windows to generate spec? Default 90 looks good, but takes longer}
 

--- a/man/prep_static_ggspectro.Rd
+++ b/man/prep_static_ggspectro.Rd
@@ -40,6 +40,8 @@ colbins=30,ampThresh=0,bgFlood=FALSE,fontAndAxisCol=NULL,optim=NULL,...)
 
 \item{ampTrans}{amplitude transform for boosting spectrum contrast; default=1 (actual dB values); specify a decimal number for the lambda value of scales::modulus_trans(); 2.5 is a good place to start. (This amplifies your loud values the most, while not increasing background noise much at all)}
 
+\item{resampleRate}{a number in Hz to downsample audio for spectrogram only. This will simplify audio data and speed up generation of spectrogram. Passed to [tuneR::downsample()]. Default=15000 shaves off a few seconds without losing much quality. Put NULL to keep original sample rate for spectrogram. Audiofile will not be resampled for MP4.}
+
 \item{min_dB}{the minimum decibel (quietest sound) to include in the spec; defaults to -30 (-40 would include quieter sounds; -20 would cut out all but very loud sounds)}
 
 \item{wl}{window length for the spectrogram (low values= higher temporal res; high values= higher freq. res). Default 512 is a good tradeoff; human speech would look better at 1024 or higher, giving higher frequency resolution.}

--- a/man/prep_static_ggspectro.Rd
+++ b/man/prep_static_ggspectro.Rd
@@ -6,10 +6,35 @@
 \alias{prepStaticGGspec}
 \title{Generate ggplot2-based spectrogram(s), which can be passed to paged_spectro}
 \usage{
-prep_static_ggspectro(soundFile,destFolder,outFilename,savePNG=FALSE,colPal="inferno",
-crop=NULL,bg=NULL,filter=NULL,xLim=NULL,yLim=c(0,10),plotLegend=FALSE,onlyPlotSpec=TRUE,
-ampTrans=1,min_dB=-30,wl=512, ovlp=90,wn="blackman",specWidth=9,specHeight=3,
-colbins=30,ampThresh=0,bgFlood=FALSE,fontAndAxisCol=NULL,optim=NULL,...)
+prep_static_ggspectro(
+  soundFile,
+  destFolder,
+  outFilename = NULL,
+  savePNG = FALSE,
+  colPal = "inferno",
+  crop = NULL,
+  bg = NULL,
+  filter = NULL,
+  xLim = NULL,
+  yLim = c(0, 10),
+  title = NULL,
+  plotLegend = FALSE,
+  onlyPlotSpec = TRUE,
+  ampTrans = 1,
+  resampleRate = 15000,
+  min_dB = -30,
+  wl = 512,
+  ovlp = 90,
+  wn = "blackman",
+  specWidth = 9,
+  specHeight = 3,
+  colbins = 30,
+  ampThresh = 0,
+  bgFlood = FALSE,
+  fontAndAxisCol = NULL,
+  optim = NULL,
+  ...
+)
 }
 \arguments{
 \item{soundFile}{should work with URLs, full and relative paths; handles .mp3 and .wav}

--- a/man/prep_static_ggspectro.Rd
+++ b/man/prep_static_ggspectro.Rd
@@ -32,6 +32,8 @@ colbins=30,ampThresh=0,bgFlood=FALSE,fontAndAxisCol=NULL,optim=NULL,...)
 
 \item{yLim}{the frequency limits (y-axis); default is c(0,10) aka 0-10kHz}
 
+\item{title}{string for title of plots; default=NULL}
+
 \item{plotLegend}{logical; include a legend showing amplitude colors? default=FALSE}
 
 \item{onlyPlotSpec}{logical; do you want to just plot the spec and leave out the legend, axes, and axis labels? default= TRUE}
@@ -98,12 +100,15 @@ bgFlood=TRUE)
 maleBarnSwallow<-prep_static_ggspectro(f[2],destFolder="wd",onlyPlotSpec = FALSE,
 bgFlood=TRUE,ampTrans=2,min_dB=-40)
 
-#much stronger, now let's combine them (you need the cowplot package)
+#much stronger, now let's combine them 
+(you need the patchwork package to use the / operator to stack plots)
+library(patchwork)
+(femaleBarnSwallow$spec[[1]]+ggplot2::xlim(0,5)) /
+(maleBarnSwallow$spec[[1]]+ggplot2::xlim(0,5))  + 
+patchwork::plot_annotation(title="Female and Male barn swallow songs",
+caption="Female song (top) is much shorter, but similar complexity to males. See: MR Wilkins et al. (2020) Animal Behaviour 168")
 
-# cowplot::plot_grid(femaleBarnSwallow$spec[[1]]+xlim(0,5)+ggtitle("female barn swallow song"),
-# maleBarnSwallow$spec[[1]]+xlim(0,5)+ggtitle("male barn swallow song"),ncol=1,labels="auto")
-
-# ggsave("M&F_barn_swallow_song_specs.jpeg")
+# ggplot2::ggsave("M&F_barn_swallow_song_specs.jpeg",width=11,height=7)
 
 # see more examples at https://marce10.github.io/dynaSpec/
 }


### PR DESCRIPTION
1. Refactored logic for cropping and paging spectrograms. Much more coherent and accurate behavior.
2. Added support for titling the spectrograms exported by prep_static_ggspectro() and scrolling_spectro()
3. Added reSample parameter to both of the above functions, with default 15000 samples/sec downsampling. Greatly speeds up rendering and gives flexibility to user.